### PR TITLE
quat_action support for a different device

### DIFF
--- a/roma/utils.py
+++ b/roma/utils.py
@@ -256,7 +256,7 @@ def quat_action(q, v, is_normalized=False):
     """
     batch_shape = v.shape[:-1]
     iquat = quat_conjugation(q) if is_normalized else quat_inverse(q)
-    pure = torch.cat((v, torch.zeros(batch_shape + (1,))), dim=-1)
+    pure = torch.cat((v, torch.zeros(batch_shape + (1,), device = q.device)), dim=-1)
     res = quat_product(q, quat_product(pure, iquat))
     return res[...,:3]
 


### PR DESCRIPTION
`quat_action` created a tensor that did not have a defined device.  This commit chooses the same device as `q` for this tensor.